### PR TITLE
Add observability: granular SSE events, detailed logging, responsive UI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,10 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       - OLLAMA_URL=http://host.docker.internal:11434
+      - LOG_LEVEL=DEBUG
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     restart: unless-stopped

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -1,6 +1,7 @@
 """Ollama API client."""
 
 import os
+import time
 import logging
 from typing import Any
 
@@ -39,6 +40,9 @@ async def generate(
     if system:
         payload["system"] = system
 
+    logger.debug(f"Ollama request: model={model}, prompt_len={len(prompt)} chars")
+
+    start = time.monotonic()
     try:
         async with httpx.AsyncClient() as client:
             response = await client.post(
@@ -48,10 +52,22 @@ async def generate(
             )
             response.raise_for_status()
             data = response.json()
-            return data.get("response", "")
+            result = data.get("response", "")
+
+        duration_ms = (time.monotonic() - start) * 1000
+
+        if not result:
+            logger.warning(f"Ollama returned empty response for model={model}")
+        else:
+            logger.info(f"Ollama responded in {duration_ms:.0f}ms, response_len={len(result)} chars")
+            logger.debug(f"Ollama response preview: {result[:200]}")
+
+        return result
     except httpx.TimeoutException:
-        logger.error(f"Ollama request timed out after {timeout}s")
+        duration_ms = (time.monotonic() - start) * 1000
+        logger.error(f"Ollama request timed out after {duration_ms:.0f}ms (limit {timeout}s)")
         raise
     except Exception as e:
-        logger.error(f"Ollama request failed: {e}")
+        duration_ms = (time.monotonic() - start) * 1000
+        logger.error(f"Ollama request failed after {duration_ms:.0f}ms: {e}")
         raise

--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,28 @@
 """FastAPI application entry point."""
 
+import logging
+import os
+
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 from pathlib import Path
 
 from src.api.routes import router
+
+# Configure logging before anything else
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    force=True,
+)
+# Prevent uvicorn from overriding our config
+logging.getLogger("uvicorn").handlers = []
+logging.getLogger("uvicorn.access").handlers = []
+
+logger = logging.getLogger(__name__)
+logger.info(f"Logging configured at level {LOG_LEVEL}")
 
 app = FastAPI(title="Docrawl", version="0.1.0")
 

--- a/src/scraper/markdown.py
+++ b/src/scraper/markdown.py
@@ -12,7 +12,9 @@ CHUNK_OVERLAP = 200
 
 def html_to_markdown(html: str) -> str:
     """Convert HTML to Markdown using markdownify."""
-    return md(html, heading_style="ATX", strip=["script", "style", "nav", "footer"])
+    result = md(html, heading_style="ATX", strip=["script", "style", "nav", "footer"])
+    logger.info(f"HTML to MD: {len(html)} chars -> {len(result)} chars")
+    return result
 
 
 def chunk_markdown(text: str, chunk_size: int = DEFAULT_CHUNK_SIZE) -> list[str]:
@@ -22,6 +24,7 @@ def chunk_markdown(text: str, chunk_size: int = DEFAULT_CHUNK_SIZE) -> list[str]
     Tries to split at paragraph boundaries.
     """
     if len(text) <= chunk_size:
+        logger.info(f"Single chunk: {len(text)} chars (under {chunk_size} limit)")
         return [text]
 
     chunks: list[str] = []
@@ -49,5 +52,6 @@ def chunk_markdown(text: str, chunk_size: int = DEFAULT_CHUNK_SIZE) -> list[str]
         # Move position with overlap for context continuity
         current_pos = end_pos - CHUNK_OVERLAP if end_pos < len(text) else end_pos
 
-    logger.info(f"Split markdown into {len(chunks)} chunks")
+    chunk_sizes = [len(c) for c in chunks]
+    logger.info(f"Split markdown into {len(chunks)} chunks, sizes: {chunk_sizes}")
     return chunks

--- a/src/scraper/page.py
+++ b/src/scraper/page.py
@@ -1,9 +1,12 @@
 """Page scraping with Playwright."""
 
+import time
 import logging
 from playwright.async_api import async_playwright, Browser, Page
 
 logger = logging.getLogger(__name__)
+
+SLOW_PAGE_THRESHOLD_S = 10.0
 
 
 class PageScraper:
@@ -32,8 +35,16 @@ class PageScraper:
 
         page = await self._browser.new_page()
         try:
+            start = time.monotonic()
             await page.goto(url, timeout=timeout, wait_until="networkidle")
+            load_time_s = time.monotonic() - start
+
+            logger.info(f"Navigated to {url} in {load_time_s:.1f}s")
+            if load_time_s > SLOW_PAGE_THRESHOLD_S:
+                logger.warning(f"Slow page load: {url} took {load_time_s:.1f}s")
+
             html = await page.inner_html("body")
+            logger.debug(f"Extracted HTML from {url}: {len(html)} chars")
             return html
         finally:
             await page.close()

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -70,20 +70,126 @@
             display: none;
         }
         .btn-danger:hover { background: #dc2626; }
-        .log {
+
+        /* Status bar */
+        .status-bar {
+            display: none;
+            margin-top: 1.5rem;
+            padding: 1rem;
+            background: #1e293b;
+            border-radius: 0.5rem;
+            border: 1px solid #334155;
+        }
+        .status-bar.active { display: block; }
+        .status-top {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 0.75rem;
+        }
+        .status-phase {
+            font-weight: 600;
+            font-size: 1rem;
+            color: #f8fafc;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+        .status-timer {
+            color: #94a3b8;
+            font-family: monospace;
+            font-size: 0.875rem;
+        }
+
+        /* Spinner */
+        .spinner {
+            display: inline-block;
+            width: 14px;
+            height: 14px;
+            border: 2px solid #475569;
+            border-top-color: #3b82f6;
+            border-radius: 50%;
+            animation: spin 0.8s linear infinite;
+        }
+        @keyframes spin { to { transform: rotate(360deg); } }
+
+        /* Progress bar */
+        .progress-container {
+            display: none;
+            height: 6px;
+            background: #334155;
+            border-radius: 3px;
+            overflow: hidden;
+            margin-top: 0.5rem;
+        }
+        .progress-container.active { display: block; }
+        .progress-bar {
+            height: 100%;
+            background: #3b82f6;
+            border-radius: 3px;
+            transition: width 0.3s, background 0.3s;
+            width: 0%;
+        }
+        .progress-bar.warning { background: #eab308; }
+        .progress-bar.error { background: #ef4444; }
+
+        /* Log */
+        .log-header {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
             margin-top: 2rem;
+            margin-bottom: 0.5rem;
+        }
+        .log-header h2 {
+            font-size: 1rem;
+            color: #94a3b8;
+        }
+        .log-badge {
+            background: #334155;
+            color: #94a3b8;
+            padding: 0.125rem 0.5rem;
+            border-radius: 999px;
+            font-size: 0.75rem;
+            font-family: monospace;
+        }
+        .log {
             padding: 1rem;
             background: #1e293b;
             border-radius: 0.5rem;
             font-family: monospace;
-            font-size: 0.875rem;
+            font-size: 0.813rem;
             max-height: 400px;
             overflow-y: auto;
+            line-height: 1.5;
         }
-        .log-entry { padding: 0.25rem 0; border-bottom: 1px solid #334155; }
+        .log-entry { padding: 0.2rem 0; border-bottom: 1px solid #1a2332; }
         .log-entry.error { color: #f87171; }
         .log-entry.success { color: #4ade80; }
         .log-entry.info { color: #60a5fa; }
+        .log-entry.muted { color: #64748b; font-size: 0.75rem; }
+        .log-entry.llm-wait { color: #a78bfa; }
+
+        /* Collapsible page groups */
+        .page-group { margin: 0.25rem 0; }
+        .page-group-header {
+            cursor: pointer;
+            user-select: none;
+            padding: 0.3rem 0;
+            border-bottom: 1px solid #1a2332;
+        }
+        .page-group-header:hover { background: rgba(255,255,255,0.02); }
+        .page-group-header .arrow {
+            display: inline-block;
+            width: 12px;
+            font-size: 0.7rem;
+            color: #64748b;
+            transition: transform 0.2s;
+        }
+        .page-group.collapsed .arrow { transform: rotate(-90deg); }
+        .page-group-body { padding-left: 1.25rem; }
+        .page-group.collapsed .page-group-body { display: none; }
+
         .summary {
             margin-top: 1rem;
             padding: 1rem;
@@ -146,7 +252,24 @@
             </div>
         </form>
 
-        <div class="log" id="log"></div>
+        <div class="status-bar" id="statusBar">
+            <div class="status-top">
+                <div class="status-phase">
+                    <span class="spinner" id="statusSpinner"></span>
+                    <span id="statusPhase">Starting...</span>
+                </div>
+                <div class="status-timer" id="statusTimer">00:00</div>
+            </div>
+            <div class="progress-container" id="progressContainer">
+                <div class="progress-bar" id="progressBar"></div>
+            </div>
+        </div>
+
+        <div class="log-header" id="logHeader" style="display:none;">
+            <h2>Log</h2>
+            <span class="log-badge" id="logBadge">0</span>
+        </div>
+        <div class="log" id="log" style="display:none;"></div>
 
         <div class="summary" id="summary">
             <h3>Results</h3>
@@ -164,10 +287,26 @@
         const cancelBtn = document.getElementById('cancelBtn');
         const modelSelect = document.getElementById('model');
         const logDiv = document.getElementById('log');
+        const logHeader = document.getElementById('logHeader');
+        const logBadge = document.getElementById('logBadge');
         const summaryDiv = document.getElementById('summary');
+        const statusBar = document.getElementById('statusBar');
+        const statusPhase = document.getElementById('statusPhase');
+        const statusSpinner = document.getElementById('statusSpinner');
+        const statusTimer = document.getElementById('statusTimer');
+        const progressContainer = document.getElementById('progressContainer');
+        const progressBar = document.getElementById('progressBar');
 
         let currentJobId = null;
         let eventSource = null;
+        let timerInterval = null;
+        let jobStartTime = null;
+        let eventCount = 0;
+        let pagesTotal = 0;
+        let pagesCompleted = 0;
+        let hasPartial = false;
+        let hasErrors = false;
+        let currentPageGroup = null;
 
         // Load models on page load
         async function loadModels() {
@@ -183,23 +322,109 @@
             }
         }
 
+        function formatDuration(ms) {
+            if (ms < 1000) return ms + 'ms';
+            return (ms / 1000).toFixed(1) + 's';
+        }
+
+        function formatTimer(seconds) {
+            const m = Math.floor(seconds / 60).toString().padStart(2, '0');
+            const s = (seconds % 60).toString().padStart(2, '0');
+            return `${m}:${s}`;
+        }
+
+        function formatBytes(bytes) {
+            if (bytes < 1024) return bytes + ' B';
+            if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+            return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+        }
+
         function log(message, type = '') {
+            eventCount++;
+            logBadge.textContent = eventCount;
+
             const entry = document.createElement('div');
             entry.className = `log-entry ${type}`;
             entry.textContent = `[${new Date().toLocaleTimeString()}] ${message}`;
+            return entry;
+        }
+
+        function appendToLog(entry) {
             logDiv.appendChild(entry);
             logDiv.scrollTop = logDiv.scrollHeight;
+        }
+
+        function appendToCurrentGroup(entry) {
+            if (currentPageGroup) {
+                currentPageGroup.querySelector('.page-group-body').appendChild(entry);
+            } else {
+                appendToLog(entry);
+            }
+            logDiv.scrollTop = logDiv.scrollHeight;
+        }
+
+        function logToMain(message, type) {
+            appendToLog(log(message, type));
+        }
+
+        function logToGroup(message, type) {
+            appendToCurrentGroup(log(message, type));
+        }
+
+        function setPhase(text) {
+            statusPhase.textContent = text;
+        }
+
+        function updateProgress() {
+            if (pagesTotal === 0) return;
+            const pct = Math.round((pagesCompleted / pagesTotal) * 100);
+            progressBar.style.width = pct + '%';
+            progressBar.className = 'progress-bar';
+            if (hasErrors) progressBar.classList.add('error');
+            else if (hasPartial) progressBar.classList.add('warning');
         }
 
         function setRunning(running) {
             startBtn.disabled = running;
             cancelBtn.style.display = running ? 'block' : 'none';
+            if (running) {
+                statusBar.classList.add('active');
+                logHeader.style.display = 'flex';
+                logDiv.style.display = 'block';
+            }
+        }
+
+        function startTimer() {
+            jobStartTime = Date.now();
+            timerInterval = setInterval(() => {
+                const elapsed = Math.floor((Date.now() - jobStartTime) / 1000);
+                statusTimer.textContent = formatTimer(elapsed);
+            }, 1000);
+        }
+
+        function stopTimer() {
+            if (timerInterval) {
+                clearInterval(timerInterval);
+                timerInterval = null;
+            }
+            statusSpinner.style.display = 'none';
         }
 
         async function startCrawl(e) {
             e.preventDefault();
             logDiv.innerHTML = '';
             summaryDiv.style.display = 'none';
+            eventCount = 0;
+            pagesTotal = 0;
+            pagesCompleted = 0;
+            hasPartial = false;
+            hasErrors = false;
+            currentPageGroup = null;
+            logBadge.textContent = '0';
+            progressBar.style.width = '0%';
+            progressBar.className = 'progress-bar';
+            progressContainer.classList.remove('active');
+            statusSpinner.style.display = 'inline-block';
 
             const payload = {
                 url: document.getElementById('url').value,
@@ -219,60 +444,167 @@
                 });
                 const job = await res.json();
                 currentJobId = job.id;
-                log(`Job started: ${job.id}`, 'info');
+                setPhase('Starting...');
+                logToMain(`Job started: ${job.id}`, 'info');
                 setRunning(true);
+                startTimer();
                 subscribeToEvents(job.id);
             } catch (e) {
-                log(`Failed to start job: ${e.message}`, 'error');
+                logToMain(`Failed to start job: ${e.message}`, 'error');
             }
         }
 
         function subscribeToEvents(jobId) {
             eventSource = new EventSource(`/api/jobs/${jobId}/events`);
 
+            eventSource.addEventListener('browser', (e) => {
+                const data = JSON.parse(e.data);
+                if (data.status === 'starting') {
+                    logToMain('Browser starting...', 'info');
+                    setPhase('Starting browser...');
+                } else if (data.status === 'ready') {
+                    logToMain('Browser ready', 'success');
+                }
+            });
+
             eventSource.addEventListener('discovery', (e) => {
                 const data = JSON.parse(e.data);
-                log(`Discovery: ${data.phase} - ${data.status || ''} ${data.urls_found ? `(${data.urls_found} URLs)` : ''}`);
+                setPhase('Discovery');
+                const strategy = data.strategy || '';
+                if (data.status === 'trying') {
+                    logToMain(`Discovery: trying ${strategy}...`, 'info');
+                } else if (data.status === 'success') {
+                    logToMain(`Discovery: ${strategy} found ${data.urls_found} URLs`, 'success');
+                } else if (data.status === 'failed') {
+                    logToMain(`Discovery: ${strategy} found nothing`, 'muted');
+                }
             });
 
             eventSource.addEventListener('filtering', (e) => {
                 const data = JSON.parse(e.data);
-                log(`Filtering: ${data.phase} ${data.after_basic ? `(${data.after_basic} URLs)` : ''} ${data.after_llm ? `-> ${data.after_llm} URLs` : ''}`);
+                setPhase('Filtering');
+                if (data.phase === 'basic') {
+                    logToMain(`Filtering ${data.total} URLs...`, 'info');
+                } else if (data.phase === 'done') {
+                    logToMain(`Filtering done: ${data.after_llm} URLs remain`, 'success');
+                }
+            });
+
+            eventSource.addEventListener('llm_start', (e) => {
+                const data = JSON.parse(e.data);
+                const msg = data.action === 'filter'
+                    ? `Waiting for LLM: filtering ${data.urls_count} URLs...`
+                    : `Waiting for LLM: ${data.action}...`;
+                logToMain(msg, 'llm-wait');
+            });
+
+            eventSource.addEventListener('llm_done', (e) => {
+                const data = JSON.parse(e.data);
+                const dur = formatDuration(data.duration_ms);
+                if (data.result === 'ok') {
+                    logToMain(`LLM ${data.action} done (${dur})`, 'success');
+                } else {
+                    logToMain(`LLM ${data.action} failed (${dur}): ${data.error || 'unknown'}`, 'error');
+                }
+            });
+
+            eventSource.addEventListener('page_loading', (e) => {
+                const data = JSON.parse(e.data);
+                // Create a new page group
+                const group = document.createElement('div');
+                group.className = 'page-group';
+                group.dataset.url = data.url;
+                group.innerHTML = `
+                    <div class="page-group-header">
+                        <span class="arrow">&#9660;</span>
+                        <span class="log-entry info" style="display:inline; border:none; padding:0;">
+                            [${new Date().toLocaleTimeString()}] Loading ${data.url}...
+                        </span>
+                    </div>
+                    <div class="page-group-body"></div>
+                `;
+                group.querySelector('.page-group-header').addEventListener('click', () => {
+                    group.classList.toggle('collapsed');
+                });
+                logDiv.appendChild(group);
+                currentPageGroup = group;
+                logDiv.scrollTop = logDiv.scrollHeight;
+                eventCount++;
+                logBadge.textContent = eventCount;
             });
 
             eventSource.addEventListener('page_start', (e) => {
                 const data = JSON.parse(e.data);
-                log(`[${data.index}/${data.total}] Processing: ${data.url}`, 'info');
+                pagesTotal = data.total;
+                setPhase(`Scraping (${data.index}/${data.total})`);
+                progressContainer.classList.add('active');
+
+                // Update group header with load time
+                if (currentPageGroup && currentPageGroup.dataset.url === data.url) {
+                    const header = currentPageGroup.querySelector('.page-group-header span.log-entry');
+                    header.textContent = `[${new Date().toLocaleTimeString()}] [${data.index}/${data.total}] ${data.url} (loaded in ${formatDuration(data.load_time_ms)})`;
+                }
+            });
+
+            eventSource.addEventListener('chunk_progress', (e) => {
+                const data = JSON.parse(e.data);
+                if (data.action === 'cleanup_start') {
+                    logToGroup(`Chunk ${data.chunk_index}/${data.chunks_total}: cleaning up...`, 'muted');
+                } else if (data.action === 'cleanup_done') {
+                    logToGroup(`Chunk ${data.chunk_index}/${data.chunks_total}: done (${formatDuration(data.duration_ms)})`, 'muted');
+                } else if (data.action === 'cleanup_failed') {
+                    logToGroup(`Chunk ${data.chunk_index}/${data.chunks_total}: failed after ${data.retries} retries (${formatDuration(data.duration_ms)})`, 'error');
+                }
+            });
+
+            eventSource.addEventListener('file_saved', (e) => {
+                const data = JSON.parse(e.data);
+                logToGroup(`Saved: ${data.path} (${formatBytes(data.size_bytes)})`, 'muted');
             });
 
             eventSource.addEventListener('page_done', (e) => {
                 const data = JSON.parse(e.data);
+                pagesCompleted++;
+                if (data.status === 'partial') hasPartial = true;
+                updateProgress();
+
                 const msg = data.chunks_failed > 0
                     ? `Done (${data.chunks_failed}/${data.chunks_total} chunks failed)`
                     : 'Done';
-                log(`  -> ${msg}`, data.status === 'ok' ? 'success' : '');
+                logToGroup(msg, data.status === 'ok' ? 'success' : '');
+                currentPageGroup = null;
             });
 
             eventSource.addEventListener('page_error', (e) => {
                 const data = JSON.parse(e.data);
-                log(`  -> Error: ${data.error}`, 'error');
+                pagesCompleted++;
+                hasErrors = true;
+                updateProgress();
+                logToGroup(`Error: ${data.error}`, 'error');
+                currentPageGroup = null;
             });
 
             eventSource.addEventListener('job_done', (e) => {
                 const data = JSON.parse(e.data);
-                log(`Job completed! Output: ${data.output_path}`, 'success');
+                setPhase('Done');
+                stopTimer();
+                logToMain(`Job completed! Output: ${data.output_path}`, 'success');
                 showSummary(data);
                 cleanup();
             });
 
             eventSource.addEventListener('job_cancelled', (e) => {
                 const data = JSON.parse(e.data);
-                log(`Job cancelled. Processed ${data.pages_completed}/${data.pages_total} pages.`, 'info');
+                setPhase('Cancelled');
+                stopTimer();
+                logToMain(`Job cancelled. Processed ${data.pages_completed}/${data.pages_total} pages.`, 'info');
                 cleanup();
             });
 
             eventSource.onerror = () => {
-                log('Connection lost', 'error');
+                logToMain('Connection lost', 'error');
+                setPhase('Disconnected');
+                stopTimer();
                 cleanup();
             };
         }
@@ -281,9 +613,9 @@
             if (!currentJobId) return;
             try {
                 await fetch(`/api/jobs/${currentJobId}/cancel`, { method: 'POST' });
-                log('Cancelling...', 'info');
+                logToMain('Cancelling...', 'info');
             } catch (e) {
-                log(`Failed to cancel: ${e.message}`, 'error');
+                logToMain(`Failed to cancel: ${e.message}`, 'error');
             }
         }
 


### PR DESCRIPTION
## Summary

- **Backend logging**: Configured structured logging with `LOG_LEVEL` env var. Added detailed logs to Ollama client (timing, payload size), LLM cleanup (retry tracking), LLM filter (URL count validation), Playwright scraper (load times, slow page warnings), and markdown converter (chunk details).
- **SSE events**: Added granular events in the job runner — `browser` lifecycle, per-strategy `discovery` cascade, `llm_start`/`llm_done` with timing, `chunk_progress` for cleanup tracking, `file_saved` with size, and `page_loading` before fetch.
- **UI overhaul**: New status bar with phase indicator, CSS spinner, and elapsed timer. Progress bar with blue/yellow/red color coding. Collapsible page groups in the log. Event count badge. Listeners for all new SSE event types with human-readable durations and sizes.
- **Docker**: Added `LOG_LEVEL=DEBUG` and json-file log driver with 10MB rotation (3 files).

## Test plan

- [x] `docker compose up --build` and open http://localhost:8080
- [x] Launch crawl against https://docs.python.org/3/tutorial/ — verify status bar shows phase, timer, progress bar
- [x] Verify `docker logs docrawl` shows detailed timestamps and durations
- [x] Cancel a job mid-run and verify UI reflects cancelled state
- [x] Verify LLM failure fallback shows retries in logs and UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)