### PR TITLE
Fix SSE event delivery and immediate cancellation response

### DIFF
--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -271,9 +271,12 @@
                 cleanup();
             });
 
-            eventSource.onerror = () => {
-                log('Connection lost', 'error');
-                cleanup();
+            eventSource.onerror = (e) => {
+                // Only cleanup if connection is truly closed (not just a reconnect attempt)
+                if (e.target.readyState === EventSource.CLOSED) {
+                    log('Connection lost', 'error');
+                    cleanup();
+                }
             };
         }
 


### PR DESCRIPTION
## Problema

La UI no mostraba eventos SSE durante la ejecución del job, y la cancelación no se reflejaba inmediatamente. Los logs de Docker funcionaban correctamente, confirmando que el problema era en la entrega SSE.

## Causa raíz

**BUG 1 - Serialización SSE incorrecta:**
`emit_event` ponía en la queue un dict con `data` como dict anidado, pero sse-starlette requiere que `data` sea un string JSON. El browser no parseaba correctamente los eventos.

**BUG 2 - Cancelación no inmediata:**
Al cancelar, `cancel_job` seteaba `_cancelled = True` pero el evento `job_cancelled` solo se emitía cuando el runner detectaba la cancelación. Si el runner estaba bloqueado en un await a Ollama (30-120s), la UI no recibía feedback hasta que terminara.

## Solución

**Fix BUG 1:**
- `emit_event` ahora serializa `data` a JSON string con `json.dumps(data)`
- Agregado `job_error` a la lista de eventos terminales
- Keepalive también usa string JSON `"{}"`

**Fix BUG 2:**
- `cancel_job` del manager ahora emite `job_cancelled` inmediatamente después de `job.cancel()`
- Removidas todas las llamadas a `_emit_cancelled` del runner
- Eliminada la función helper `_emit_cancelled`
- La UI recibe el evento de cancelación al instante

**Mejora UI:**
- `eventSource.onerror` ahora solo hace cleanup si `readyState === CLOSED`, evitando cierres prematuros durante reconexiones automáticas

## Testing

- [x] `docker compose up --build` y verificar que eventos SSE llegan en tiempo real
- [x] Cancelar un job durante scraping y verificar que la UI muestra "Cancelled" inmediatamente
- [x] Verificar en consola del browser (F12) que no hay errores de parseo JSON
- [x] Confirmar que timer se detiene y status bar refleja cancelación

🤖 Generated with [Claude Code](https://claude.com/claude-code)