### PR TITLE
fix: cleanup pipeline performance — pre-clean HTML, smarter chunking, faster timeouts

### DIFF
--- a/src/llm/cleanup.py
+++ b/src/llm/cleanup.py
@@ -1,50 +1,90 @@
-"""LLM-based markdown cleanup."""
+"""LLM-based markdown cleanup with smart skip and dynamic timeouts."""
 
+import asyncio
+import re
 import logging
 
 from src.llm.client import generate
 
 logger = logging.getLogger(__name__)
 
-CLEANUP_SYSTEM_PROMPT = """You are a documentation cleaner. Your job is to clean up markdown
-converted from HTML documentation pages. Remove navigation residue, footers, ads, and fix formatting issues.
-Keep all actual documentation content intact."""
+CLEANUP_SYSTEM_PROMPT = """You are a documentation cleaner. Clean up markdown from HTML docs.
+Remove navigation residue, footers, ads, fix formatting. Keep all documentation content intact."""
 
-CLEANUP_PROMPT_TEMPLATE = """Clean up this markdown documentation. Remove:
-- Navigation menus and breadcrumbs
-- Footer content (copyright, links)
-- Sidebar residue
-- Advertisements
-- Broken formatting
+CLEANUP_PROMPT_TEMPLATE = """Clean this markdown. Remove nav menus, breadcrumbs, footer, sidebar residue, ads, broken formatting.
+Keep all documentation content, code examples, and links.
+Return only cleaned markdown.
 
-Keep all actual documentation content, code examples, and important links.
-Return only the cleaned markdown, no explanations.
-
-Markdown to clean:
 {markdown}"""
 
-MAX_RETRIES = 3
-RETRY_BACKOFF = [2, 5, 10]  # seconds
+MAX_RETRIES = 2
+RETRY_BACKOFF = [1, 3]  # seconds
+
+# Dynamic timeout constants
+BASE_TIMEOUT = 45       # seconds for small chunks
+TIMEOUT_PER_KB = 10     # extra seconds per KB of content
+MAX_TIMEOUT = 90        # cap
+
+# Noise indicators for needs_llm_cleanup()
+_NOISE_INDICATORS = [
+    "cookie", "privacy policy", "terms of service", "subscribe",
+    "toggle dark", "toggle light", "dark mode", "light mode",
+    "skip to content", "table of contents", "on this page",
+    "all rights reserved", "powered by",
+]
+
+_CODE_BLOCK_RE = re.compile(r"```[\s\S]*?```")
+
+
+def needs_llm_cleanup(markdown: str) -> bool:
+    """Check if a chunk needs LLM cleanup or is already clean.
+
+    Returns False for chunks that are mostly code or short clean text.
+    """
+    lower = markdown.lower()
+
+    # Check for noise indicators
+    has_noise = any(indicator in lower for indicator in _NOISE_INDICATORS)
+    if has_noise:
+        return True
+
+    # Check code block density — mostly code chunks are clean
+    code_blocks = _CODE_BLOCK_RE.findall(markdown)
+    code_chars = sum(len(b) for b in code_blocks)
+    if code_chars > len(markdown) * 0.6:
+        return False
+
+    # Short clean text doesn't need LLM
+    if len(markdown) < 2000:
+        return False
+
+    return True
+
+
+def _calculate_timeout(content: str) -> int:
+    """Calculate dynamic timeout based on chunk size."""
+    content_kb = len(content) / 1024
+    timeout = int(BASE_TIMEOUT + content_kb * TIMEOUT_PER_KB)
+    return min(timeout, MAX_TIMEOUT)
 
 
 async def cleanup_markdown(markdown: str, model: str) -> str:
-    """
-    Use LLM to clean up markdown content.
+    """Use LLM to clean up markdown content.
 
-    Retries with exponential backoff on failure.
+    Uses dynamic timeout based on chunk size. Retries with backoff.
     Returns original content if all retries fail.
     """
     prompt = CLEANUP_PROMPT_TEMPLATE.format(markdown=markdown)
+    timeout = _calculate_timeout(markdown)
 
     for attempt in range(MAX_RETRIES):
         try:
-            cleaned = await generate(model, prompt, system=CLEANUP_SYSTEM_PROMPT)
+            cleaned = await generate(model, prompt, system=CLEANUP_SYSTEM_PROMPT, timeout=timeout)
             if cleaned.strip():
                 return cleaned.strip()
         except Exception as e:
-            logger.warning(f"Cleanup attempt {attempt + 1} failed: {e}")
+            logger.warning(f"Cleanup attempt {attempt + 1} failed ({timeout}s timeout): {e}")
             if attempt < MAX_RETRIES - 1:
-                import asyncio
                 await asyncio.sleep(RETRY_BACKOFF[attempt])
 
     logger.error("All cleanup attempts failed, returning original")

--- a/src/scraper/page.py
+++ b/src/scraper/page.py
@@ -1,13 +1,44 @@
-"""Page scraping with Playwright."""
+"""Page scraping with Playwright — includes DOM noise removal."""
 
 import logging
 from playwright.async_api import async_playwright, Browser, Page
 
 logger = logging.getLogger(__name__)
 
+# Selectors for noise elements to remove before extraction
+NOISE_SELECTORS = [
+    "script", "style", "noscript", "iframe",
+    "nav", "footer", "header",
+    "[role='navigation']", "[role='banner']", "[role='contentinfo']",
+    ".sidebar", "#sidebar",
+    ".navbar", "#navbar",
+    ".table-of-contents", "#table-of-contents",
+    ".breadcrumb", ".footer", ".header",
+    ".cookie-banner",
+    "[id*='mintlify']",
+    ".prev-next-links", ".pagination-nav",
+    ".edit-this-page", ".last-updated",
+    ".theme-toggle", ".search-bar", "[data-search]",
+]
+
+# Selectors to try for main content extraction (in priority order)
+CONTENT_SELECTORS = [
+    "main",
+    "article",
+    "[role='main']",
+    "#content",
+    ".content",
+    ".markdown-body",
+    ".docs-content",
+    ".documentation",
+    "#main-content",
+]
+
+MIN_CONTENT_LENGTH = 200
+
 
 class PageScraper:
-    """Scrapes pages using Playwright."""
+    """Scrapes pages using Playwright with DOM pre-cleaning."""
 
     def __init__(self) -> None:
         self._browser: Browser | None = None
@@ -25,15 +56,46 @@ class PageScraper:
             self._browser = None
             logger.info("Browser stopped")
 
+    async def _remove_noise(self, page: Page) -> None:
+        """Remove noise elements from the DOM before extraction."""
+        selector_list = ", ".join(NOISE_SELECTORS)
+        removed = await page.evaluate(f"""() => {{
+            const els = document.querySelectorAll(`{selector_list}`);
+            let count = 0;
+            els.forEach(el => {{ el.remove(); count++; }});
+            return count;
+        }}""")
+        if removed:
+            logger.debug(f"Removed {removed} noise elements from DOM")
+
+    async def _extract_content(self, page: Page) -> str:
+        """Extract main content HTML, trying specific selectors before body fallback."""
+        for selector in CONTENT_SELECTORS:
+            try:
+                el = await page.query_selector(selector)
+                if el:
+                    html = await el.inner_html()
+                    if len(html) >= MIN_CONTENT_LENGTH:
+                        logger.debug(f"Extracted content via '{selector}' ({len(html)} chars)")
+                        return html
+            except Exception:
+                continue
+
+        # Fallback to body
+        html = await page.inner_html("body")
+        logger.debug(f"Fallback to body extraction ({len(html)} chars)")
+        return html
+
     async def get_html(self, url: str, timeout: int = 30000) -> str:
-        """Navigate to URL and extract body HTML."""
+        """Navigate to URL, clean DOM, and extract content HTML."""
         if not self._browser:
             raise RuntimeError("Browser not started")
 
         page = await self._browser.new_page()
         try:
             await page.goto(url, timeout=timeout, wait_until="networkidle")
-            html = await page.inner_html("body")
+            await self._remove_noise(page)
+            html = await self._extract_content(page)
             return html
         finally:
             await page.close()


### PR DESCRIPTION
## Summary

Performance optimizations for the cleanup pipeline to reduce LLM calls and processing time.

- **DOM pre-cleaning** — Remove noise elements (nav, footer, sidebar, cookie banners, etc.) from the DOM before HTML extraction using Playwright's `page.evaluate()`
- **Content-focused extraction** — Try specific content selectors (`main`, `article`, `[role='main']`, etc.) before falling back to `body`
- **Markdown pre-cleaning + larger chunks** — Regex-based noise removal (Next.js hydration, JS DOM manipulation, framework attributes, noise lines) before chunking. Chunk size increased from 8K to 16K chars
- **Dynamic timeouts** — Calculate timeout based on chunk size (45s base + 10s/KB, max 90s) instead of fixed 120s. Reduced retries from 3 to 2
- **Smart LLM skip** — Skip LLM cleanup for chunks that are already clean (>60% code blocks or <2000 chars without noise indicators)

## Issues

- Closes #11 — HTML pre-cleaning: remove noise from DOM before extraction
- Closes #12 — Markdown pre-cleaning + larger chunks
- Closes #13 — Dynamic timeout reduction for LLM cleanup
- Closes #14 — Skip LLM cleanup for already-clean chunks

## Files changed

- `src/scraper/page.py` — DOM noise removal + content selector cascade
- `src/scraper/markdown.py` — Pre-cleaning patterns + chunk size increase
- `src/llm/cleanup.py` — Dynamic timeout, `needs_llm_cleanup()`, reduced retries
- `src/jobs/runner.py` — Integrate `needs_llm_cleanup` skip logic with logging

## Test plan

- [x] Run crawl on a docs site and verify noise elements are removed from output
- [x] Verify chunks are larger and pre-cleaned before LLM processing
- [x] Check logs for "⚡ skip (clean)" messages on code-heavy pages
- [x] Verify dynamic timeouts in cleanup logs
- [x] Confirm no regression in markdown output quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)