### PR TITLE
feat: optimize Ollama inference parameters for cleanup and filtering

### DIFF
--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -29,6 +29,7 @@ async def generate(
     prompt: str,
     system: str | None = None,
     timeout: int = 120,
+    options: dict[str, Any] | None = None,
 ) -> str:
     """Generate text using Ollama."""
     payload: dict[str, Any] = {
@@ -38,6 +39,8 @@ async def generate(
     }
     if system:
         payload["system"] = system
+    if options:
+        payload["options"] = options
 
     try:
         async with httpx.AsyncClient() as client:

--- a/src/llm/filter.py
+++ b/src/llm/filter.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from typing import Any
 
 from src.llm.client import generate
 
@@ -22,6 +23,14 @@ Return a JSON array of filtered URLs, ordered by suggested reading order (basics
 Only return the JSON array, no other text."""
 
 
+FILTER_OPTIONS: dict[str, Any] = {
+    "num_ctx": 4096,
+    "num_predict": 2048,
+    "temperature": 0.0,
+    "num_batch": 1024,
+}
+
+
 async def filter_urls_with_llm(urls: list[str], model: str) -> list[str]:
     """
     Use LLM to filter and order documentation URLs.
@@ -34,7 +43,7 @@ async def filter_urls_with_llm(urls: list[str], model: str) -> list[str]:
     prompt = FILTER_PROMPT_TEMPLATE.format(urls="\n".join(urls))
 
     try:
-        response = await generate(model, prompt, system=FILTER_SYSTEM_PROMPT)
+        response = await generate(model, prompt, system=FILTER_SYSTEM_PROMPT, options=FILTER_OPTIONS)
 
         # Try to parse JSON from response
         # Handle potential markdown code blocks


### PR DESCRIPTION
## Summary

Passes inference parameters (`options`) to the Ollama API to prevent silent failures and improve performance.

Closes #16

## Changes

- **`src/llm/client.py`** — `generate()` accepts optional `options: dict` param, forwards to Ollama payload
- **`src/llm/cleanup.py`** — Dynamic `_cleanup_options()` per chunk: `num_ctx: 8192`, `num_predict` capped to input size + margin (max 4096), `temperature: 0.1`, `num_batch: 1024`
- **`src/llm/filter.py`** — Static `FILTER_OPTIONS`: `num_ctx: 4096`, `num_predict: 2048`, `temperature: 0.0`, `num_batch: 1024`

## Why each parameter matters

| Parameter | Problem without it | Value |
|---|---|---|
| `num_ctx` | Default 2048-4096 silently truncates 16K char chunks → garbage output | 8192 (cleanup), 4096 (filter) |
| `num_predict` | Model generates tokens indefinitely → wasted time, hallucinated content | Capped to input size (cleanup), 2048 (filter) |
| `temperature` | Default 0.8 adds randomness to mechanical tasks → inconsistent results | 0.1 (cleanup), 0.0 (filter) |
| `num_batch` | Default 512 → slower prompt evaluation | 1024 for both |

## Backwards compatible

`options` defaults to `None` in `generate()` — existing callers work unchanged.

## Test plan

- [x] Run cleanup on large doc page, verify no context truncation warnings
- [x] Check that cleanup output length is bounded (no hallucinated extra content)
- [x] Verify filtering returns consistent results across runs (temperature 0.0)
- [x] Confirm no regression in markdown quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)