### PR TITLE
fix: SSE connection stability — ping, reconnection, error boundaries

### DIFF
--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -39,7 +39,11 @@ async def job_events(job_id: str) -> EventSourceResponse:
     job = job_manager.get_job(job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
-    return EventSourceResponse(job.event_stream())
+    return EventSourceResponse(
+        job.event_stream(),
+        ping=15,            # send SSE comment every 15s to keep connection alive
+        ping_message_factory=lambda: "keepalive",
+    )
 
 
 @router.post("/jobs/{job_id}/cancel")

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -531,11 +531,63 @@
                 cleanupJob();
             });
 
+            eventSource.addEventListener('keepalive', (e) => {
+                // Silently consume keepalive events — these keep the connection alive
+            });
+
             eventSource.onerror = (e) => {
-                if (e.target.readyState === EventSource.CLOSED) {
-                    logMessage('Connection lost', 'failed', 'error');
-                    cleanupJob();
+                if (!currentJobId) return;
+
+                // Close the dead EventSource
+                if (eventSource) {
+                    eventSource.close();
+                    eventSource = null;
                 }
+
+                // Check if job is still running before giving up
+                fetch(`/api/jobs/${currentJobId}/status`)
+                    .then(r => r.json())
+                    .then(status => {
+                        if (status.status === 'running' || status.status === 'pending') {
+                            logMessage('Connection interrupted, reconnecting...', 'init', 'warning');
+                            setTimeout(() => {
+                                if (currentJobId) {
+                                    subscribeToEvents(currentJobId);
+                                }
+                            }, 2000);
+                        } else if (status.status === 'completed') {
+                            logMessage('Job completed (reconnected)', 'done');
+                            updatePhaseBanner('done', `Completed ${status.pages_completed} pages`);
+                            cleanupJob();
+                        } else if (status.status === 'cancelled') {
+                            logMessage(`Job cancelled. Processed ${status.pages_completed}/${status.pages_total} pages.`, 'cancelled');
+                            updatePhaseBanner('cancelled', `${status.pages_completed}/${status.pages_total} pages`);
+                            cleanupJob();
+                        } else {
+                            logMessage('Connection lost — job may have failed', 'failed', 'error');
+                            cleanupJob();
+                        }
+                    })
+                    .catch(() => {
+                        logMessage('Backend unreachable, retrying...', 'init', 'warning');
+                        setTimeout(() => {
+                            if (currentJobId) {
+                                fetch(`/api/jobs/${currentJobId}/status`)
+                                    .then(r => r.json())
+                                    .then(status => {
+                                        if (status.status === 'running') {
+                                            subscribeToEvents(currentJobId);
+                                        } else {
+                                            cleanupJob();
+                                        }
+                                    })
+                                    .catch(() => {
+                                        logMessage('Connection lost', 'failed', 'error');
+                                        cleanupJob();
+                                    });
+                            }
+                        }, 5000);
+                    });
             };
         }
 


### PR DESCRIPTION
## Summary

Fixes SSE connection drops that occur mid-job during long cleanup operations, causing "Connection lost" in the UI while the backend continues running.

Closes #19

## Changes

### 1. SSE ping configuration (`routes.py`)
Configure `EventSourceResponse` with `ping=15` — sends SSE comment every 15s **independently** of the event generator. Keeps the TCP connection alive through Cloudflare Tunnel (~100s idle timeout) and Docker networking during long Ollama calls (up to 90s).

### 2. Dead runner detection (`manager.py`)
- Store reference to the asyncio task (`job._task`) when creating a job
- In `event_stream()`, check on each keepalive cycle if the runner task has died without emitting a terminal event
- If dead, emit `job_done` with error and break the stream — prevents the generator from blocking forever

### 3. Error boundary in runner finally block (`runner.py`)
- Wrap `scraper.stop()` in try/except so a browser cleanup failure doesn't prevent terminal event emission
- Add safety net: if `job.status` is still "running" when `finally` executes, emit `job_done` with failure status
- Wrap error event emission in try/except so a queue error doesn't mask the original exception

### 4. Frontend reconnection logic (`index.html`)
- On SSE error, **don't immediately give up** — poll `/api/jobs/{id}/status` first
- If job is still running: log "Connection interrupted, reconnecting..." and re-subscribe after 2s
- If job completed/cancelled while disconnected: show appropriate final state
- If backend unreachable: retry once after 5s, then give up
- Add keepalive event listener (no-op, prevents EventSource confusion)

## Test plan

- [ ] Run a 20+ page crawl and verify no "Connection lost" during normal operation
- [ ] Simulate network interruption (disable/enable network) — should reconnect automatically
- [ ] Kill Ollama mid-cleanup — should show proper error, not "Connection lost"
- [ ] Verify keepalive ping visible in browser DevTools Network tab (SSE stream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)