### PR TITLE
fix: mirror all SSE events to docker logs with timestamps

### DIFF
--- a/src/jobs/runner.py
+++ b/src/jobs/runner.py
@@ -18,6 +18,25 @@ from src.scraper.markdown import html_to_markdown, chunk_markdown
 logger = logging.getLogger(__name__)
 
 
+async def _log(job: Job, event_type: str, data: dict) -> None:
+    """Emit SSE event and log the message to stdout."""
+    await job.emit_event(event_type, data)
+    msg = data.get("message", "")
+    if msg:
+        phase = data.get("phase", "")
+        model = data.get("active_model", "")
+        level = data.get("level", "")
+        prefix = f"[{job.id[:8]}] [{phase}]" if phase else f"[{job.id[:8]}]"
+        suffix = f" [{model}]" if model else ""
+        full_msg = f"{prefix} {msg}{suffix}"
+        if level == "error":
+            logger.error(full_msg)
+        elif level == "warning":
+            logger.warning(full_msg)
+        else:
+            logger.info(full_msg)
+
+
 async def run_job(job: Job) -> None:
     """Execute a crawl job with enriched phase/model SSE events."""
     # TODO: reasoning_model will be used for:
@@ -34,12 +53,12 @@ async def run_job(job: Job) -> None:
 
     try:
         # INIT phase
-        await job.emit_event("phase_change", {
+        await _log(job, "phase_change", {
             "phase": "init",
             "message": "Initializing browser...",
         })
         await scraper.start()
-        await job.emit_event("phase_change", {
+        await _log(job, "phase_change", {
             "phase": "init",
             "message": "Browser ready",
         })
@@ -49,13 +68,13 @@ async def run_job(job: Job) -> None:
             await robots.load(base_url)
             if robots.crawl_delay:
                 delay_s = max(request.delay_ms / 1000, robots.crawl_delay)
-                await job.emit_event("log", {
+                await _log(job, "log", {
                     "phase": "init",
                     "message": f"robots.txt loaded (crawl-delay: {robots.crawl_delay}s, using {delay_s}s)",
                 })
             else:
                 delay_s = request.delay_ms / 1000
-                await job.emit_event("log", {
+                await _log(job, "log", {
                     "phase": "init",
                     "message": "robots.txt loaded (no crawl-delay)",
                 })
@@ -64,7 +83,7 @@ async def run_job(job: Job) -> None:
 
         # DISCOVERY phase
         phase_start = time.monotonic()
-        await job.emit_event("phase_change", {
+        await _log(job, "phase_change", {
             "phase": "discovery",
             "message": "Crawling site structure...",
         })
@@ -72,7 +91,7 @@ async def run_job(job: Job) -> None:
         urls = await discover_urls(base_url, request.max_depth)
 
         discovery_time = time.monotonic() - phase_start
-        await job.emit_event("log", {
+        await _log(job, "log", {
             "phase": "discovery",
             "message": f"Found {len(urls)} URLs ({discovery_time:.1f}s)",
         })
@@ -83,7 +102,7 @@ async def run_job(job: Job) -> None:
         # FILTERING phase — basic
         phase_start = time.monotonic()
         total_before = len(urls)
-        await job.emit_event("phase_change", {
+        await _log(job, "phase_change", {
             "phase": "filtering",
             "message": "Applying basic filters...",
         })
@@ -91,7 +110,7 @@ async def run_job(job: Job) -> None:
         urls = filter_urls(urls, base_url)
         after_basic = len(urls)
         removed_basic = total_before - after_basic
-        await job.emit_event("log", {
+        await _log(job, "log", {
             "phase": "filtering",
             "message": f"Basic filtering: {total_before} → {after_basic} URLs (removed {removed_basic} non-doc)",
         })
@@ -102,14 +121,14 @@ async def run_job(job: Job) -> None:
             urls = [u for u in urls if robots.is_allowed(u)]
             removed_robots = before_robots - len(urls)
             if removed_robots > 0:
-                await job.emit_event("log", {
+                await _log(job, "log", {
                     "phase": "filtering",
                     "message": f"robots.txt: {before_robots} → {len(urls)} URLs (blocked {removed_robots})",
                 })
 
         # FILTERING phase — LLM
         before_llm = len(urls)
-        await job.emit_event("phase_change", {
+        await _log(job, "phase_change", {
             "phase": "filtering",
             "active_model": request.crawl_model,
             "message": f"LLM filtering with {request.crawl_model}...",
@@ -119,7 +138,7 @@ async def run_job(job: Job) -> None:
         urls = await filter_urls_with_llm(urls, request.crawl_model)
         llm_duration = time.monotonic() - llm_start
 
-        await job.emit_event("log", {
+        await _log(job, "log", {
             "phase": "filtering",
             "active_model": request.crawl_model,
             "message": f"LLM result: {before_llm} → {len(urls)} URLs ({llm_duration:.1f}s)",
@@ -146,7 +165,7 @@ async def run_job(job: Job) -> None:
             page_start = time.monotonic()
 
             # Scraping sub-phase
-            await job.emit_event("phase_change", {
+            await _log(job, "phase_change", {
                 "phase": "scraping",
                 "message": "Loading page...",
                 "progress": f"{i + 1}/{len(urls)}",
@@ -159,7 +178,7 @@ async def run_job(job: Job) -> None:
                 markdown = html_to_markdown(html)
                 chunks = chunk_markdown(markdown)
 
-                await job.emit_event("log", {
+                await _log(job, "log", {
                     "phase": "scraping",
                     "message": f"[{i+1}/{len(urls)}] Loaded {url} ({load_time:.1f}s, {len(chunks)} chunks)",
                 })
@@ -169,7 +188,7 @@ async def run_job(job: Job) -> None:
                 chunks_failed = 0
                 cleanup_start = time.monotonic()
 
-                await job.emit_event("phase_change", {
+                await _log(job, "phase_change", {
                     "phase": "cleanup",
                     "active_model": request.pipeline_model,
                     "message": f"Cleaning {len(chunks)} chunks...",
@@ -185,7 +204,7 @@ async def run_job(job: Job) -> None:
                     if not needs_llm_cleanup(chunk):
                         cleaned_chunks.append(chunk)
                         if len(chunks) > 1:
-                            await job.emit_event("log", {
+                            await _log(job, "log", {
                                 "phase": "cleanup",
                                 "message": f"[{i+1}/{len(urls)}] Chunk {ci+1}/{len(chunks)} ⚡ skip (clean)",
                             })
@@ -199,7 +218,7 @@ async def run_job(job: Job) -> None:
 
                         # Only log individual chunks if more than 1
                         if len(chunks) > 1:
-                            await job.emit_event("log", {
+                            await _log(job, "log", {
                                 "phase": "cleanup",
                                 "active_model": request.pipeline_model,
                                 "message": f"[{i+1}/{len(urls)}] Chunk {ci+1}/{len(chunks)} ✓ ({chunk_time:.1f}s)",
@@ -207,7 +226,7 @@ async def run_job(job: Job) -> None:
                     except Exception as e:
                         chunks_failed += 1
                         cleaned_chunks.append(chunk)
-                        await job.emit_event("log", {
+                        await _log(job, "log", {
                             "phase": "cleanup",
                             "active_model": request.pipeline_model,
                             "message": f"[{i+1}/{len(urls)}] Chunk {ci+1}/{len(chunks)} ✗ failed, using raw",
@@ -229,7 +248,7 @@ async def run_job(job: Job) -> None:
                 size_str = f"{file_size / 1024:.1f} KB" if file_size >= 1024 else f"{file_size} B"
                 rel_path = str(file_path.relative_to(output_path))
 
-                await job.emit_event("log", {
+                await _log(job, "log", {
                     "phase": "save",
                     "message": f"[{i+1}/{len(urls)}] → {rel_path} ({size_str})" + (f" ⚠ {chunks_failed} chunks failed" if chunks_failed > 0 else " ✓"),
                 })
@@ -238,7 +257,7 @@ async def run_job(job: Job) -> None:
                 pages_failed += 1
                 page_time = time.monotonic() - page_start
                 logger.error(f"Failed to process {url}: {e}")
-                await job.emit_event("log", {
+                await _log(job, "log", {
                     "phase": "scraping",
                     "message": f"[{i+1}/{len(urls)}] ✗ {url}: {e} ({page_time:.1f}s)",
                     "level": "error",
@@ -251,20 +270,21 @@ async def run_job(job: Job) -> None:
             _generate_index(urls, output_path)
 
             job.status = "completed"
-            await job.emit_event("phase_change", {
+            await _log(job, "phase_change", {
                 "phase": "done",
                 "message": "Job completed",
             })
-            await job.emit_event("job_done", {
+            await _log(job, "job_done", {
                 "status": "completed",
                 "pages_ok": pages_ok,
                 "pages_partial": pages_partial,
                 "pages_failed": pages_failed,
                 "output_path": str(output_path),
+                "message": f"Done: {pages_ok} ok, {pages_partial} partial, {pages_failed} failed",
             })
 
     except Exception as e:
-        logger.error(f"Job failed: {e}")
+        logger.error(f"Job {job.id} failed: {e}")
         job.status = "failed"
         await job.emit_event("phase_change", {
             "phase": "failed",

--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,19 @@
 """FastAPI application entry point."""
 
+import logging
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 from pathlib import Path
 
 from src.api.routes import router
+
+# Configure logging with timestamps
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
 
 app = FastAPI(title="Docrawl", version="0.1.0")
 


### PR DESCRIPTION
## Summary

All job progress events now appear in `docker logs` with timestamps, matching what the UI shows.

Closes #25

## Problem

`runner.py` used `job.emit_event()` to send progress to the SSE stream but never called `logger.info()`. Docker logs only showed discovery prints (which use `print()`) and Ollama errors — filtering results, page loads, cleanup status, and save confirmations were invisible.

## Fix

### `src/jobs/runner.py`
- Add `_log()` helper that does both `emit_event()` + `logger.info/warning/error()` in one call
- Replace all `emit_event()` calls with `_log()` for the happy path
- Log format: `[job_id] [phase] message [model]`

### `src/main.py`
- Configure `logging.basicConfig()` with timestamp format: `2026-02-14 04:29:13 [src.jobs.runner] INFO: ...`

## Expected docker logs output

```
2026-02-14 04:29:13 [src.jobs.runner] INFO: [2e653f7c] [init] Browser ready
2026-02-14 04:29:13 [src.jobs.runner] INFO: [2e653f7c] [init] robots.txt loaded (no crawl-delay)
2026-02-14 04:29:15 [src.jobs.runner] INFO: [2e653f7c] [discovery] Found 126 URLs (1.4s)
2026-02-14 04:29:15 [src.jobs.runner] INFO: [2e653f7c] [filtering] Basic filtering: 126 → 4 URLs (removed 122 non-doc)
2026-02-14 04:29:19 [src.jobs.runner] INFO: [2e653f7c] [filtering] LLM result: 4 → 4 URLs (3.7s) [llama3.2:3b]
2026-02-14 04:29:23 [src.jobs.runner] INFO: [2e653f7c] [scraping] [1/4] Loaded .../gateway (3.8s, 4 chunks)
2026-02-14 04:29:50 [src.jobs.runner] INFO: [2e653f7c] [cleanup] [1/4] Chunk 1/4 ✓ (25.3s) [mistral:latest]
2026-02-14 04:29:51 [src.jobs.runner] INFO: [2e653f7c] [save] [1/4] → gateway.md (4.9 KB) ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)