### PR TITLE
fix: correct SyntaxError in routes.py conditional expression

### DIFF
--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -39,9 +39,10 @@ async def list_providers():
                 "id": p_id,
                 "name": p_id.capitalize(),
                 "configured": (
-                    True if p_id == "ollama" 
-                    else p_id == "openrouter" and bool(__import__('os').environ.get('OPENROUTER_API_KEY'))
-                    else p_id == "opencode" and bool(__import__('os').environ.get('OPENCODE_API_KEY'))
+                    p_id == "ollama"
+                    or (p_id == "openrouter" and bool(__import__('os').environ.get('OPENROUTER_API_KEY')))
+                    or (p_id == "opencode" and bool(__import__('os').environ.get('OPENCODE_API_KEY')))
+                    or False
                 ),
                 "requires_api_key": config["requires_api_key"],
             }


### PR DESCRIPTION
## Summary
Fixes #32

La expresión ternaria con `else` encadenados causaba un `SyntaxError`:
```python
True if p_id == "ollama" 
else p_id == "openrouter" and ...
else p_id == "opencode" and ...  # Invalid syntax
```

Reemplazado con operadores `or`:
```python
p_id == "ollama"
or (p_id == "openrouter" and ...)
or (p_id == "opencode" and ...)
or False
```

## Test
- [x] Python syntax validation passes