### PR TITLE
feat: add language filtering for documentation crawling

### DIFF
--- a/src/api/models.py
+++ b/src/api/models.py
@@ -6,9 +6,9 @@ from pydantic import BaseModel, HttpUrl
 class JobRequest(BaseModel):
     """Request to create a new crawl job."""
     url: HttpUrl
-    crawl_model: str          # Para discovery y filtrado de URLs
-    pipeline_model: str       # Para cleanup de markdown chunks
-    reasoning_model: str      # Para análisis de estructura y decisiones complejas
+    crawl_model: str
+    pipeline_model: str
+    reasoning_model: str
     output_path: str = "/data/output"
     delay_ms: int = 500
     max_concurrent: int = 3
@@ -17,6 +17,7 @@ class JobRequest(BaseModel):
     use_native_markdown: bool = True
     use_markdown_proxy: bool = False
     markdown_proxy_url: str = "https://markdown.new"
+    language: str = "en"
 
 
 class JobStatus(BaseModel):

--- a/src/crawler/filter.py
+++ b/src/crawler/filter.py
@@ -5,7 +5,6 @@ from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
-# Extensions to exclude
 EXCLUDED_EXTENSIONS = {
     ".pdf", ".zip", ".tar", ".gz", ".rar",
     ".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico", ".webp",
@@ -14,20 +13,32 @@ EXCLUDED_EXTENSIONS = {
     ".exe", ".dmg", ".deb", ".rpm",
 }
 
-# Path patterns to exclude
 EXCLUDED_PATTERNS = {
     "/blog/", "/changelog/", "/api-reference/",
     "/releases/", "/download/", "/assets/",
 }
 
+LANGUAGE_PATTERNS = {
+    "en": ["/en/", "/en-us/", "/en-gb/", "/english/"],
+    "es": ["/es/", "/es-es/", "/spanish/"],
+    "fr": ["/fr/", "/fr-fr/", "/french/"],
+    "de": ["/de/", "/de-de/", "/german/"],
+    "ja": ["/ja/", "/jp/", "/japanese/"],
+    "zh": ["/zh/", "/zh-cn/", "/zh-tw/", "/chinese/"],
+    "pt": ["/pt/", "/pt-br/", "/portuguese/"],
+    "ru": ["/ru/", "/russian/"],
+    "ko": ["/ko/", "/kr/", "/korean/"],
+}
 
-def filter_urls(urls: list[str], base_url: str) -> list[str]:
+
+def filter_urls(urls: list[str], base_url: str, language: str = "en") -> list[str]:
     """
     Apply deterministic filtering to URL list.
 
     - Only same domain/subpath
     - Exclude non-doc extensions
     - Exclude common non-doc patterns
+    - Filter by language (default: English only)
     - Deduplicate
     """
     base_parsed = urlparse(base_url)
@@ -39,26 +50,45 @@ def filter_urls(urls: list[str], base_url: str) -> list[str]:
     for url in urls:
         parsed = urlparse(url)
 
-        # Must be same domain
         if parsed.netloc != base_domain:
             continue
 
-        # Must be under base path
         path = parsed.path.rstrip("/")
         if not path.startswith(base_path):
             continue
 
-        # Check excluded extensions
         if any(path.lower().endswith(ext) for ext in EXCLUDED_EXTENSIONS):
             continue
 
-        # Check excluded patterns
         if any(pattern in path.lower() for pattern in EXCLUDED_PATTERNS):
             continue
 
-        # Normalize: remove fragment and query
+        if not _matches_language(path, language):
+            continue
+
         normalized = f"{parsed.scheme}://{parsed.netloc}{path}"
         filtered.add(normalized)
 
-    logger.info(f"Filtered {len(urls)} URLs down to {len(filtered)}")
+    logger.info(f"Filtered {len(urls)} URLs down to {len(filtered)} (language: {language})")
     return sorted(filtered)
+
+
+def _matches_language(path: str, language: str) -> bool:
+    """Check if URL path matches the target language."""
+    if language == "all":
+        return True
+    
+    path_lower = path.lower()
+    
+    lang_patterns = LANGUAGE_PATTERNS.get(language, [f"/{language}/"])
+    for pattern in lang_patterns:
+        if pattern in path_lower:
+            return True
+    
+    other_langs = set(LANGUAGE_PATTERNS.keys()) - {language}
+    for other_lang in other_langs:
+        for pattern in LANGUAGE_PATTERNS[other_lang]:
+            if pattern in path_lower:
+                return False
+    
+    return True

--- a/src/jobs/runner.py
+++ b/src/jobs/runner.py
@@ -107,7 +107,7 @@ async def run_job(job: Job) -> None:
             "message": "Applying basic filters...",
         })
 
-        urls = filter_urls(urls, base_url)
+        urls = filter_urls(urls, base_url, request.language)
         after_basic = len(urls)
         removed_basic = total_before - after_basic
         await _log(job, "log", {

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -314,10 +314,24 @@
                     <label for="maxDepth">Max crawl depth</label>
                     <input type="number" id="maxDepth" value="5" min="1" max="20">
                 </div>
-                <div class="form-group checkbox-group" style="align-self: end; padding-bottom: 0.75rem;">
-                    <input type="checkbox" id="respectRobots" checked>
-                    <label for="respectRobots" style="margin: 0;">Respect robots.txt</label>
+                <div class="form-group">
+                    <label for="language">Language</label>
+                    <select id="language">
+                        <option value="en">English only</option>
+                        <option value="es">Spanish only</option>
+                        <option value="fr">French only</option>
+                        <option value="de">German only</option>
+                        <option value="ja">Japanese only</option>
+                        <option value="zh">Chinese only</option>
+                        <option value="pt">Portuguese only</option>
+                        <option value="all">All languages</option>
+                    </select>
                 </div>
+            </div>
+
+            <div class="form-group checkbox-group">
+                <input type="checkbox" id="respectRobots" checked>
+                <label for="respectRobots" style="margin: 0;">Respect robots.txt</label>
             </div>
 
             <div class="models-section" style="margin-top: 1rem;">
@@ -539,6 +553,7 @@
                 use_native_markdown: document.getElementById('useNativeMarkdown').checked,
                 use_markdown_proxy: useMarkdownProxyCheckbox.checked,
                 markdown_proxy_url: document.getElementById('markdownProxyUrl').value,
+                language: document.getElementById('language').value,
             };
 
             try {


### PR DESCRIPTION
## Summary
Fixes #29 - Filtrado de idioma para evitar documentación en múltiples idiomas.

### Cambios
- **JobRequest**: nuevo campo `language` (default: `"en"`)
- **filter.py**: detecta y filtra URLs por patrones de idioma
- **UI**: selector de idioma con opciones comunes

### Patrones soportados
| Idioma | Patrones URL |
|--------|-------------|
| English | `/en/`, `/en-us/`, `/en-gb/` |
| Spanish | `/es/`, `/es-es/` |
| French | `/fr/`, `/fr-fr/` |
| German | `/de/`, `/de-de/` |
| Japanese | `/ja/`, `/jp/` |
| Chinese | `/zh/`, `/zh-cn/`, `/zh-tw/` |
| Portuguese | `/pt/`, `/pt-br/` |
| All | Sin filtro |

### Comportamiento
1. Si URL coincide con idioma target → ✅ incluir
2. Si URL coincide con otro idioma → ❌ excluir
3. Si URL no tiene patrón de idioma → ✅ incluir (asume default)

---
Signed-off-by: OpenCode 🤖 <opencode@anomaly.la>