### PR TITLE
fix(security): replace xml.etree with defusedxml to prevent XXE (#64)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ httpx>=0.26.0
 pydantic>=2.5.0
 sse-starlette>=1.8.0
 beautifulsoup4>=4.12.0
+defusedxml>=0.7.1

--- a/src/crawler/discovery.py
+++ b/src/crawler/discovery.py
@@ -3,7 +3,8 @@
 import asyncio
 import gzip
 import logging
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
+from xml.etree.ElementTree import ParseError as XMLParseError
 from collections import deque
 from typing import cast
 from urllib.parse import urljoin, urlparse, urlunparse
@@ -367,7 +368,7 @@ async def try_sitemap(base_url: str, filter_by_path: bool = True) -> list[str]:
             # Parse XML with defensive error handling
             try:
                 root = ET.fromstring(content)
-            except ET.ParseError as e:
+            except XMLParseError as e:
                 logger.warning(f"✗ Invalid XML in sitemap: {url} - {e}")
                 print(f"[DISCOVERY] ✗ Invalid XML in sitemap: {url}", flush=True)
                 return urls


### PR DESCRIPTION
## Summary

- Replaces `xml.etree.ElementTree.fromstring` with `defusedxml.ElementTree.fromstring` in the sitemap parser (`src/crawler/discovery.py:369`)
- Adds `defusedxml>=0.7.1` to `requirements.txt` (runtime dep — needed in the Docker image)
- `ParseError` is imported directly from `xml.etree.ElementTree` since `defusedxml` doesn't re-export it

## Why

The bandit B314 finding (`xml.etree.ElementTree.fromstring` parsing untrusted XML) is blocking the `security.yml` CI gate on every push to `main` — it's the only HIGH/MEDIUM finding remaining after the `-ll` flag was enabled in v0.9.2.

`defusedxml` disables all dangerous XML features (entity expansion, external entities, DTD processing) and is the standard replacement for stdlib XML parsers when handling untrusted input.

## Test plan

- [ ] CI security scan (`bandit -ll`) passes — no more B314 finding
- [ ] CI tests pass — sitemap parsing still works (no functional change, only safety wrapper)
- [ ] `pip install -r requirements.txt` installs `defusedxml` without conflicts

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)