### PR TITLE
v0.9.5 - Backlog P2 followup: cache, retry, atomic writes, logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [v0.9.5] - 2026-02-26
+
+### Fixed
+- **Model list cache with TTL (#92)** — `get_available_models()` now caches results per provider for 60s, preventing repeated HTTP calls to Ollama/OpenRouter on every job start
+- **Retry with exponential backoff in LLM filtering (#94)** — `filter_urls_with_llm()` retries up to 3 times (1s → 2s → 4s backoff) before falling back to the original URL list
+- **Atomic file writes (#99)** — scraped pages are now written to a `.tmp` file and renamed atomically, preventing corrupt output files on crash or cancellation
+- **Remove print statements from discovery.py (#89)** — all `print(f"[DISCOVERY] ...")` replaced with `logger.info()`, enabling proper log level control
+- **Exponential backoff in LLM cleanup (#100)** — retry delays changed from fixed `[1, 3]s` to exponential `2**attempt` (1s, 2s, 4s); `MAX_RETRIES` increased from 2 to 3
+
+---
+
 ## [v0.8.5] - 2026-02-20
 
 ### Added

--- a/src/jobs/runner.py
+++ b/src/jobs/runner.py
@@ -439,11 +439,13 @@ async def run_job(job: Job) -> None:
                             },
                         )
 
-                # Save sub-phase
+                # Save sub-phase — atomic write to avoid corrupt files on crash
                 final_md = "\n\n".join(cleaned_chunks)
                 file_path = _url_to_filepath(url, base_url, output_path)
                 file_path.parent.mkdir(parents=True, exist_ok=True)
-                file_path.write_text(final_md, encoding="utf-8")
+                tmp_path = file_path.with_suffix(".tmp")
+                tmp_path.write_text(final_md, encoding="utf-8")
+                tmp_path.rename(file_path)
                 file_size = file_path.stat().st_size
 
                 if chunks_failed == 0:

--- a/src/llm/cleanup.py
+++ b/src/llm/cleanup.py
@@ -18,8 +18,8 @@ Return only cleaned markdown.
 
 {markdown}"""
 
-MAX_RETRIES = 2
-RETRY_BACKOFF = [1, 3]  # seconds
+MAX_RETRIES = 3
+# Exponential backoff: 1s, 2s, 4s (2**attempt)
 
 # Dynamic timeout constants
 BASE_TIMEOUT = 45  # seconds for small chunks
@@ -118,7 +118,7 @@ async def cleanup_markdown(markdown: str, model: str) -> str:
                 f"Cleanup attempt {attempt + 1} failed ({timeout}s timeout): {e}"
             )
             if attempt < MAX_RETRIES - 1:
-                await asyncio.sleep(RETRY_BACKOFF[attempt])
+                await asyncio.sleep(2**attempt)  # 1s, 2s, 4s
 
     logger.error("All cleanup attempts failed, returning original")
     return markdown

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -3,12 +3,17 @@
 # 🤖 Generated with AI assistance by DocCrawler 🕷️ (model: qwen3-coder:free) and human review.
 
 import os
+import time
 import logging
 from typing import Any
 
 import httpx
 
 logger = logging.getLogger(__name__)
+
+# Model list cache: provider -> (models, timestamp)
+_model_cache: dict[str, tuple[list[dict[str, Any]], float]] = {}
+MODEL_CACHE_TTL = 60  # seconds
 
 # Environment variables
 OLLAMA_URL = os.environ.get("OLLAMA_URL", "http://localhost:11434")
@@ -51,15 +56,26 @@ PROVIDER_MODELS = {
 
 
 async def get_available_models(provider: str = "ollama") -> list[dict[str, Any]]:
-    """Get list of available models for a provider."""
+    """Get list of available models for a provider. Results cached for MODEL_CACHE_TTL seconds."""
+    now = time.monotonic()
+    cached = _model_cache.get(provider)
+    if cached is not None:
+        models, ts = cached
+        if now - ts < MODEL_CACHE_TTL:
+            logger.debug(f"Model cache hit for provider '{provider}'")
+            return models
+
     if provider == "ollama":
-        return await _get_ollama_models()
+        models = await _get_ollama_models()
     elif provider == "openrouter":
-        return _get_openrouter_models()
+        models = _get_openrouter_models()
     elif provider == "opencode":
-        return _get_opencode_models()
+        models = _get_opencode_models()
     else:
         return []
+
+    _model_cache[provider] = (models, now)
+    return models
 
 
 async def _get_ollama_models() -> list[dict[str, Any]]:


### PR DESCRIPTION
## Resumen

Followup del PR #116 — implementa los 5 fixes identificados en code review que no estaban en el commit original.

### Issues cerrados

- **Closes #92** — Cache de modelos con TTL (60s) en `get_available_models()`: evita llamadas HTTP repetidas a Ollama/OpenRouter en cada inicio de job
- **Closes #94** — Retry con backoff exponencial en `filter_urls_with_llm()`: 3 intentos (1s → 2s → 4s) antes de fallback a lista original
- **Closes #99** — Atomic writes: archivos scrapeados se escriben a `.tmp` y se renombran atómicamente, evitando output corrupto en crash o cancelación
- **Closes #89** — Eliminar `print()` de `discovery.py`: todos los `print(f"[DISCOVERY] ...")` reemplazados por `logger.info()` para control correcto de log level
- **Closes #100** — Backoff exponencial en cleanup: delays cambiados de `[1, 3]s` fijo a `2**attempt` (1s, 2s, 4s); `MAX_RETRIES` aumentado de 2 a 3

### Archivos modificados

| Archivo | Fix |
|---------|-----|
| `src/llm/client.py` | Cache TTL para model lists (#92) |
| `src/llm/filter.py` | Retry + backoff exponencial (#94) |
| `src/jobs/runner.py` | Atomic writes via .tmp + rename (#99) |
| `src/crawler/discovery.py` | print → logger.info (#89) |
| `src/llm/cleanup.py` | Backoff exponencial, MAX_RETRIES 2→3 (#100) |
| `CHANGELOG.md` | v0.9.5 entry |

## Test plan

- [ ] CI tests pasan (95/95)
- [ ] Verificar en run real que no aparecen `[DISCOVERY]` en stdout
- [ ] Verificar que model list se cachea (log "Model cache hit" en segundo request)
- [ ] Simular crash durante job y verificar que no quedan archivos `.tmp` corruptos

🤖 Generated with [Claude Code](https://claude.com/claude-code)