### PR TITLE
fix(ui): footer fixed at bottom of viewport — v0.9.6b

### DIFF
--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -34,6 +34,7 @@
             color: var(--text-primary);
             min-height: 100vh;
             padding: 1.5rem;
+            padding-bottom: 3rem;
             font-size: 18px;
             line-height: 1.4;
             position: relative;
@@ -937,15 +938,18 @@
 
         /* ── App Footer ──────────────────────────────────────────────────── */
         .app-footer {
-            position: relative;
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
             z-index: 1001;
             text-align: center;
-            padding: 1.5rem 0 0.75rem;
+            padding: 0.45rem 1rem;
             font-size: 0.72em;
             color: var(--text-dim);
             letter-spacing: 0.05em;
-            max-width: 900px;
-            margin: 0 auto;
+            background: rgba(0,0,0,0.55);
+            backdrop-filter: blur(4px);
         }
         .app-footer .footer-name { font-weight: bold; color: var(--text-primary); opacity: 0.7; }
         .app-footer .footer-sep { opacity: 0.3; margin: 0 0.45em; }


### PR DESCRIPTION
## Summary
- Footer was invisible: `position: relative` placed it below the fold (after `display:none .summary`)
- Changed `.app-footer` to `position: fixed; bottom: 0; left: 0; right: 0` — always visible in all 3 themes
- Added semi-transparent `background + backdrop-filter` so footer text is readable over page content
- Added `padding-bottom: 3rem` to `body` to prevent content from being obscured by the fixed footer

## Test plan
- [ ] Build Docker image and open UI
- [ ] Verify footer visible in Synthwave (default) theme
- [ ] Verify footer visible in Terminal theme
- [ ] Verify footer visible in Basic theme
- [ ] Verify footer shows dynamic version from `/api/info` after page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)