### PR TITLE
fix(ui): send phase_change before scraping loop

### DIFF
--- a/src/jobs/runner.py
+++ b/src/jobs/runner.py
@@ -675,6 +675,16 @@ async def run_job(
 
         # PR 3.3: opt-in pipeline mode (producer/consumer) vs default concurrent scraping
         if request.use_pipeline_mode:
+            # Notify UI of scraping phase start (fixes UI stuck on "filtering")
+            await _log(
+                job,
+                "phase_change",
+                {
+                    "phase": "scraping",
+                    "message": f"Processing {len(urls)} pages (pipeline mode)...",
+                    "progress": f"0/{len(urls)}",
+                },
+            )
             (
                 pages_ok,
                 pages_partial,
@@ -699,6 +709,16 @@ async def run_job(
                 delay_s=delay_s,
             )
         else:
+            # Notify UI of scraping phase start before loop (fixes UI stuck on "filtering")
+            await _log(
+                job,
+                "phase_change",
+                {
+                    "phase": "scraping",
+                    "message": f"Processing {len(urls)} pages...",
+                    "progress": f"0/{len(urls)}",
+                },
+            )
             # Launch all pages concurrently, semaphore controls actual parallelism
             await asyncio.gather(*[_process_page(i, url) for i, url in enumerate(urls)])
 


### PR DESCRIPTION
## Summary

Fixes UI stuck on "filtering" phase when job transitions to scraping.

## Problem

When using a slow local LLM (like gemma3:4b), the UI remained stuck showing "filtering" even though the job had already moved to the scraping/cleanup phase. This happened because there was no `phase_change` event emitted when the scraping loop started.

## Solution

Emit a `phase_change` event with phase "scraping" **before** the scraping loop begins (both for normal mode and pipeline mode). This ensures the UI immediately updates to show the scraping phase as soon as filtering completes.

## Changes

- `src/jobs/runner.py`: Added `phase_change` event emission before:
  - Normal scraping loop (line 702-711)
  - Pipeline mode scraping (line 678-687)

## Testing

Verified with local Ollama - UI now correctly shows "Processing N pages..." immediately after filtering completes.

## Checklist

- [x] Tests pass
- [x] Lint passes
- [x] Documentation updated if needed

---

Closes: (to be filled by reviewer)