### PR TITLE
fix(ci): add git pull --rebase before push in auto-commit workflows

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -52,4 +52,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -m "docs: auto-update SNAPSHOT.md [skip ci]"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/update-docs-on-merge.yml
+++ b/.github/workflows/update-docs-on-merge.yml
@@ -167,6 +167,7 @@ jobs:
           git add README.md CHANGELOG.md
           if ! git diff --staged --quiet; then
             git commit -m "chore: update README + CHANGELOG after PR #${{ github.event.pull_request.number }} [skip ci]"
+            git pull --rebase origin main
             git push origin main
             echo "Committed and pushed."
           else

--- a/.github/workflows/update-memory.yml
+++ b/.github/workflows/update-memory.yml
@@ -53,5 +53,6 @@ jobs:
             echo "No changes to docs/MEMORY.md"
           else
             git commit -m "docs: auto-update MEMORY.md [skip ci]"
+            git pull --rebase origin main
             git push
           fi


### PR DESCRIPTION
Prevents non-fast-forward push failures when concurrent commits land on main between checkout and push in snapshot, memory, and docs workflows.