### PR TITLE
fix: harden docker-publish against silent failures and bad tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,15 +1,24 @@
 name: Publish Docker Image
 
-# Triggered when a GitHub Release is published (created by the Release workflow).
-# Using `release: published` instead of `workflow_run` avoids the Scorecard
-# DangerousWorkflow pattern: workflow_run + explicit ref checkout is always
-# flagged regardless of whether the ref is trusted. With `release`, the
-# trigger fires with the tag SHA as github.sha and no explicit ref is needed.
+# Triggered when a GitHub Release is published — whether via the Release
+# workflow, the web UI, CLI, or API. Using `release: published` instead of
+# `workflow_run` avoids the Scorecard DangerousWorkflow pattern (workflow_run
+# + explicit ref checkout flagged when checkout is performed). With `release`,
+# github.sha points to the tagged ref and actions/checkout resolves it without
+# any user-controlled input.
+#
+# Note: unlike workflow_run, this trigger has no ordering guarantee relative
+# to the Release workflow. Both may run concurrently. The "Verify release
+# notes" step below acts as a gate: if the Release workflow hasn't populated
+# the release body yet (or failed to do so), this job aborts rather than
+# publishing a Docker image for an incomplete release.
 on:
   release:
     types: [published]
 
 concurrency:
+  # cancel-in-progress: false — cancelling a mid-flight push would leave a
+  # partial image in GHCR. Duplicate publishes for the same tag queue instead.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
@@ -24,9 +33,22 @@ jobs:
     timeout-minutes: 25
 
     steps:
+      - name: Verify release notes present
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          BODY=$(gh release view "${TAG_NAME}" --json body --jq '.body')
+          if [ -z "$BODY" ] || [ "$BODY" = "null" ]; then
+            echo "::error::Release body is empty — Release workflow may not have run or failed. Aborting Docker publish."
+            exit 1
+          fi
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        # No explicit ref needed: the release trigger sets github.sha to the
-        # tag's commit and actions/checkout uses that by default.
+        # No explicit ref needed: on a release event, github.sha points to the
+        # tagged ref (commit SHA for lightweight tags, tag object SHA for
+        # annotated tags). actions/checkout resolves both correctly, checking
+        # out the tagged commit without any user-controlled input.
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
@@ -47,6 +69,10 @@ jobs:
         run: |
           RAW="${TAG_NAME}"
           VERSION="${RAW#v}"                     # strip leading 'v' → 0.9.10
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.+)?$ ]]; then
+            echo "::error::TAG_NAME '${TAG_NAME}' is not valid semver (got VERSION='${VERSION}'). Aborting."
+            exit 1
+          fi
           MINOR="${VERSION%.*}"                  # drop patch → 0.9
           IS_STABLE=$([[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && echo true || echo false)
           echo "version=$VERSION"  >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Follows up the Scorecard DangerousWorkflow fix (c56bae0) with hardening identified during PR review:

- **Add release-notes gate**: new first step aborts the publish job if the release body is empty, replacing the sequencing guarantee that `workflow_run: conclusion == success` previously provided. Catches manual releases, race conditions with `release.yml`, and Release workflow failures.
- **Add semver validation**: `Parse semver from tag` now exits 1 on non-semver tags (e.g. `vtest`, `v`) instead of silently pushing malformed image tags to GHCR.
- **Fix `github.sha` comment inaccuracy**: previous comment said "sets github.sha to the tag's commit" — only true for lightweight tags. Annotated tags (GitHub's default) set `github.sha` to the tag object SHA; `actions/checkout` resolves both correctly. Comment now describes this accurately.
- **Document trigger tradeoffs**: header comments now explain that `release: published` fires for any release source with no ordering guarantee vs `release.yml`, and that the release-notes guard is what provides the gate.

## Test plan

- [x] Verify workflow lints cleanly (`actionlint` or CI)
- [x] Trigger a release with a valid tag — confirm publish succeeds
- [x] Confirm that creating a release with an empty body causes the publish job to fail at the "Verify release notes present" step
- [x] Confirm that pushing a non-semver tag (e.g. `vtest`) causes the publish job to fail at "Parse semver from tag"

🤖 Generated with [Claude Code](https://claude.com/claude-code)