### PR TITLE
fix(security): sanitize CSS selectors and warn on skip_llm_cleanup misuse

### DIFF
--- a/src/api/models.py
+++ b/src/api/models.py
@@ -1,5 +1,7 @@
 """Pydantic models for API request/response."""
 
+import logging
+import re
 from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
@@ -7,6 +9,11 @@ from urllib.parse import urlparse
 from pydantic import BaseModel, HttpUrl, Field, field_validator, model_validator
 
 from src.utils.security import validate_url_not_ssrf
+
+logger = logging.getLogger(__name__)
+
+# Characters that would break a JS template literal if interpolated verbatim.
+_UNSAFE_SELECTOR_RE = re.compile(r"[`{}]")
 
 
 class JobRequest(BaseModel):
@@ -76,6 +83,10 @@ class JobRequest(BaseModel):
         for sel in v:
             if len(sel) > 200:
                 raise ValueError(f"Selector too long (max 200 chars): {sel[:50]}...")
+            if _UNSAFE_SELECTOR_RE.search(sel):
+                raise ValueError(
+                    f"Selector contains unsafe characters (backtick or braces): {sel[:50]}"
+                )
         return v
 
     @field_validator("output_path")
@@ -129,6 +140,12 @@ class JobRequest(BaseModel):
             raise ValueError(
                 "pipeline_model is required unless skip_llm_cleanup=True or "
                 "a ReaderLM converter is used (converter='readerlm' / 'readerlm-v1')."
+            )
+        if self.skip_llm_cleanup and self.converter not in _READERLM_CONVERTERS:
+            logger.warning(
+                "skip_llm_cleanup=True on a non-ReaderLM job (converter=%r). "
+                "LLM cleanup will be skipped entirely — set intentionally?",
+                self.converter,
             )
         return self
 

--- a/tests/api/test_models.py
+++ b/tests/api/test_models.py
@@ -1,5 +1,6 @@
 """Tests for src/api/models.py — JobRequest validators, OllamaModel, and JobStatus."""
 
+import logging
 import pytest
 from unittest.mock import patch, MagicMock
 from pydantic import ValidationError
@@ -483,3 +484,85 @@ class TestValidateSelectors:
         with pytest.raises(ValidationError) as exc_info:
             JobRequest(**_minimal_request(noise_selectors=[long_selector]))
         assert "too long" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# validate_selectors — unsafe character rejection (Issue #177)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateSelectorsUnsafeChars:
+    """Selectors with backtick or braces must be rejected to prevent JS template literal injection."""
+
+    def test_content_selector_with_backtick_raises(self):
+        """Selector containing backtick must be rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            JobRequest(**_minimal_request(content_selectors=[".foo`; evilCode(); `"]))
+        assert "unsafe characters" in str(exc_info.value)
+
+    def test_noise_selector_with_backtick_raises(self):
+        """Noise selector containing backtick must be rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            JobRequest(**_minimal_request(noise_selectors=[".bar`injection`"]))
+        assert "unsafe characters" in str(exc_info.value)
+
+    def test_selector_with_open_brace_raises(self):
+        """Selector containing '{' must be rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            JobRequest(**_minimal_request(content_selectors=[".cls{color:red}"]))
+        assert "unsafe characters" in str(exc_info.value)
+
+    def test_selector_with_close_brace_raises(self):
+        """Selector containing '}' must be rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            JobRequest(**_minimal_request(content_selectors=[".cls}"]))
+        assert "unsafe characters" in str(exc_info.value)
+
+    def test_normal_selector_no_backtick_accepted(self):
+        """Normal CSS selectors without unsafe chars must be accepted."""
+        req = JobRequest(
+            **_minimal_request(
+                content_selectors=[".main-content", "#article", "div.docs > p"]
+            )
+        )
+        assert req.content_selectors == [".main-content", "#article", "div.docs > p"]
+
+    def test_selector_with_brackets_accepted(self):
+        """Attribute selectors using [] are safe and must be accepted."""
+        req = JobRequest(
+            **_minimal_request(content_selectors=["[data-testid='main']", "a[href]"])
+        )
+        assert len(req.content_selectors) == 2
+
+
+# ---------------------------------------------------------------------------
+# validate_models_required — skip_llm_cleanup warning (Issue #178)
+# ---------------------------------------------------------------------------
+
+
+class TestSkipLlmCleanupWarning:
+    """skip_llm_cleanup=True on a non-ReaderLM job should emit a warning."""
+
+    def test_skip_llm_cleanup_non_readerlm_logs_warning(self, caplog):
+        """Warning must be logged when skip_llm_cleanup=True and converter is not ReaderLM."""
+        with caplog.at_level(logging.WARNING, logger="src.api.models"):
+            JobRequest(url="https://example.com", skip_llm_cleanup=True)
+        assert any("skip_llm_cleanup=True" in r.message for r in caplog.records)
+
+    def test_skip_llm_cleanup_with_readerlm_no_warning(self, caplog):
+        """No warning must be emitted when converter='readerlm' (expected usage)."""
+        with caplog.at_level(logging.WARNING, logger="src.api.models"):
+            JobRequest(url="https://example.com", converter="readerlm")
+        assert not any("skip_llm_cleanup" in r.message for r in caplog.records)
+
+    def test_skip_llm_cleanup_with_readerlm_v1_no_warning(self, caplog):
+        """No warning must be emitted when converter='readerlm-v1'."""
+        with caplog.at_level(logging.WARNING, logger="src.api.models"):
+            JobRequest(url="https://example.com", converter="readerlm-v1")
+        assert not any("skip_llm_cleanup" in r.message for r in caplog.records)
+
+    def test_skip_llm_cleanup_false_no_warning(self, caplog):
+        """No warning must be emitted when skip_llm_cleanup=False (default)."""
+        with caplog.at_level(logging.WARNING, logger="src.api.models"):
+            JobRequest(**_minimal_request())
+        assert not any("skip_llm_cleanup" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

- Rejects CSS selectors containing backtick or brace characters before they can be interpolated into `page.evaluate()` template literals, preventing JS injection in the browser context.
- Emits a `WARNING` log when `skip_llm_cleanup=True` is used with a non-ReaderLM converter, surfacing accidental misuse at job-creation time instead of silently skipping LLM cleanup.
- Adds `TestValidateSelectorsUnsafeChars` and `TestSkipLlmCleanupWarning` test classes.

Closes #177
Closes #178

## Test plan

- [x] `pytest tests/api/test_models.py::TestValidateSelectorsUnsafeChars` — all 6 cases pass
- [x] `pytest tests/api/test_models.py::TestSkipLlmCleanupWarning` — all 4 cases pass
- [x] `pytest tests/api/` — no regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)