### PR TITLE
fix(ci): move permissions to job level (TokenPermissions)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,15 +22,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
-permissions:
-  contents: read
-  packages: write
-  id-token: write
+permissions: read-all
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
 
     steps:
       - name: Verify release notes present

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -13,13 +13,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: write
+permissions: read-all
 
 jobs:
   snapshot:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/.github/workflows/update-memory.yml
+++ b/.github/workflows/update-memory.yml
@@ -15,8 +15,7 @@ on:
     paths-ignore:
       - 'docs/MEMORY.md'
 
-permissions:
-  contents: write
+permissions: read-all
 
 concurrency:
   group: update-memory-${{ github.ref }}
@@ -26,6 +25,8 @@ jobs:
   update-memory:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
     # Skip if the commit message contains [skip ci] to avoid loops
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
 


### PR DESCRIPTION
## Summary

Mueve los bloques \`permissions:\` de nivel workflow a nivel job en tres workflows, añadiendo \`permissions: read-all\` como baseline restrictivo a nivel workflow.

| Workflow | Permisos movidos al job |
|---|---|
| \`docker-publish.yml\` | \`packages: write\`, \`id-token: write\`, \`contents: read\` |
| \`snapshot.yml\` | \`contents: write\` |
| \`update-memory.yml\` | \`contents: write\` |

Resuelve Scorecard TokenPermissionsID (alerts 61, 50, 24).

Closes #183

## Test plan

- [x] lint workflow pasa en este PR
- [x] security workflow pasa en este PR
- [x] test workflow pasa en este PR
- [x] YAML válido para los 3 archivos modificados

🤖 Generated with [Claude Code](https://claude.com/claude-code)