### PR TITLE
test(exceptions): add coverage for LLMProviderError hierarchy

### DIFF
--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -600,7 +600,9 @@ def _assert_not_catches(exc: BaseException, exc_type: type) -> None:
             caught = True
     except type(exc):
         pass  # propagated as expected
-    assert not caught, f"{type(exc).__name__} should not be caught as {exc_type.__name__}"
+    assert not caught, (
+        f"{type(exc).__name__} should not be caught as {exc_type.__name__}"
+    )
 
 
 class TestLLMExceptionHierarchy:
@@ -631,8 +633,12 @@ class TestLLMExceptionHierarchy:
 
     def test_llm_errors_not_caught_as_unrelated_docrawl_subclass(self):
         """LLM errors are not accidentally caught by unrelated DocrawlError subclasses."""
-        _assert_not_catches(LLMConnectionError(provider="ollama"), OllamaNotRunningError)
+        _assert_not_catches(
+            LLMConnectionError(provider="ollama"), OllamaNotRunningError
+        )
 
     def test_different_llm_subtypes_not_interchangeable(self):
         """LLMTimeoutError is not caught by an except clause for LLMConnectionError."""
-        _assert_not_catches(LLMTimeoutError(provider="openai", timeout_s=5), LLMConnectionError)
+        _assert_not_catches(
+            LLMTimeoutError(provider="openai", timeout_s=5), LLMConnectionError
+        )


### PR DESCRIPTION
## Summary
- Adds 28 new tests covering `LLMProviderError`, `LLMConnectionError`, `LLMTimeoutError`, and `LLMRateLimitError` — the four LLM exception classes that had no test coverage
- Extends the imports block in `tests/test_exceptions.py` with the four new classes
- Adds `TestLLMExceptionHierarchy` to verify all LLM exceptions are catchable as `LLMProviderError`, `DocrawlError`, and `Exception`

## Test plan
- [x] `pytest tests/test_exceptions.py` — all 71 tests pass
- [x] Coverage for `src/exceptions.py` reaches 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new public LLM-related exception types for provider failures, connection issues, timeouts, and rate limiting, including provider-aware messages and user-facing hints.
* **Tests**
  * Expanded test coverage to validate exception attributes, string formatting and hints, inheritance/catchability across error hierarchies, and distinct behaviors among LLM error subtypes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->